### PR TITLE
Fix build breakages for VS2015+

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,9 @@ my %param = (
     OBJECT        => 'CMom$(OBJ_EXT) Constant$(OBJ_EXT) CResults$(OBJ_EXT) ODBC$(OBJ_EXT)',
     XS            => { 'ODBC.xs' => 'ODBC.cpp' },
 );
+if ($Config{'cc'} =~ /^cl/i && (split(/[.]/, $Config{'ccversion'}))[0] >= 19) {
+    $param{LIBS} = 'legacy_stdio_wide_specifiers.lib legacy_stdio_definitions.lib';
+}
 $param{INC} = '-GX'                     if $Config{'cc'} =~ /^cl/i;
 $param{INC} = '-I$Config{incpath}\\mfc' if $Config{'cc'} =~ /^bcc32/i;
 $param{NO_META} = 1 if eval "$ExtUtils::MakeMaker::VERSION" >= 6.10_03;


### PR DESCRIPTION
This PR address build issues with VS2015+

Reference: https://social.msdn.microsoft.com/Forums/vstudio/en-US/b63a5ba5-71a9-4758-a6ea-a419836c3285/vs-2015-unresolved-external-when-linking-to-odbc-libs?forum=vcgeneral

```
        link -out:blib\arch\auto\Win32\ODBC\ODBC.dll -dll -nologo -nodefaultlib -debug -opt:ref,icf
-ltcg  -libpath:"C:\dev\tmp\perl\cpan\perl\install\perl\lib\mswin32\CORE"  -machine:x64 -subsystem:c
onsole,"5.02" CMom.obj Constant.obj CResults.obj ODBC.obj   "C:\dev\tmp\perl\cpan\perl\install\perl\
lib\mswin32\CORE\perl526.lib" oldnames.lib kernel32.lib user32.lib gdi32.lib winspool.lib  comdlg32.
lib advapi32.lib shell32.lib ole32.lib oleaut32.lib  netapi32.lib uuid.lib ws2_32.lib mpr.lib winmm.
lib  version.lib odbc32.lib odbccp32.lib comctl32.lib msvcrt.lib vcruntime.lib ucrt.lib -def:ODBC.de
f
   Creating library blib\arch\auto\Win32\ODBC\ODBC.lib and object blib\arch\auto\Win32\ODBC\ODBC.exp

odbccp32.lib(dllload.obj) : error LNK2001: unresolved external symbol _vsnwprintf_s
blib\arch\auto\Win32\ODBC\ODBC.dll : fatal error LNK1120: 1 unresolved externals
NMAKE :  U1077: 'C:\VS2017\VC\Tools\MSVC\14.10.25017\bin\HostX64\x64\link.EXE' : return code '0x460'
```